### PR TITLE
chore: README cleanup (remove stats/stargazers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,4 +675,3 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 🌟 Stargazers
 
-[![Stargazers repo roster for @muhittincamdali/iOSDevelopmentTools](https://starchart.cc/muhittincamdali/iOSDevelopmentTools.svg)](https://github.com/muhittincamdali/iOSDevelopmentTools/stargazers)


### PR DESCRIPTION
Removes analytics/stargazers sections to keep README focused.