### PR TITLE
docs: add Examples/Documentation index

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,0 +1,29 @@
+# Documentation Index
+
+- [](&)Documentation/AnalyticsAPI.md
+- [](&)Documentation/AnalyticsGuide.md
+- [](&)Documentation/API-Reference.md
+- [](&)Documentation/API.md
+- [](&)Documentation/Best-Practices.md
+- [](&)Documentation/BestPracticesGuide.md
+- [](&)Documentation/ConfigurationAPI.md
+- [](&)Documentation/DebuggingGuide.md
+- [](&)Documentation/DebuggingToolsAPI.md
+- [](&)Documentation/DevelopmentToolsManagerAPI.md
+- [](&)Documentation/Getting-Started.md
+- [](&)Documentation/GettingStarted.md
+- [](&)Documentation/Installation.md
+- [](&)Documentation/LoggingAPI.md
+- [](&)Documentation/LoggingGuide.md
+- [](&)Documentation/NetworkGuide.md
+- [](&)Documentation/PerformanceAPI.md
+- [](&)Documentation/PerformanceGuide.md
+- [](&)Documentation/ProfilingGuide.md
+- [](&)Documentation/ProfilingToolsAPI.md
+- [](&)Documentation/ReportingAPI.md
+- [](&)Documentation/StorageAPI.md
+- [](&)Documentation/StorageGuide.md
+- [](&)Documentation/TestingGuide.md
+- [](&)Documentation/TestingToolsAPI.md
+- [](&)Documentation/Troubleshooting.md
+- [](&)Documentation/UtilityGuide.md

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,24 +1,11 @@
-# 💡 Examples
+# Examples Index
 
-Welcome to our comprehensive examples collection! Here you'll find practical implementations and usage patterns for our framework.
-
-## 📱 Available Examples
-
-### Basic Example
-- **File**: `BasicExample.swift`
-- **Description**: Simple implementation showing fundamental usage
-- **Difficulty**: Beginner
-- **Use Case**: Quick prototyping and learning
-
-## 🚀 Getting Started
-
-1. **Choose an example** that matches your skill level
-2. **Copy the code** into your project
-3. **Customize** according to your needs
-4. **Build and run** to see it in action
-
-## 📚 Related Documentation
-
-- [Getting Started](Documentation/GettingStarted.md)
-- [API Reference](Documentation/API.md)
-- [Installation Guide](Documentation/Installation.md)
+- ``Examples/AdvancedExample.swift
+- ``Examples/AdvancedExample/AdvancedExample.swift
+- ``Examples/BasicExample.swift
+- ``Examples/BasicExample/BasicExample.swift
+- ``Examples/CustomExample/CustomExample.swift
+- ``Examples/DebuggingExamples/DebuggingExample.swift
+- ``Examples/PerformanceExamples/PerformanceExample.swift
+- ``Examples/ProfilingExamples/ProfilingExample.swift
+- ``Examples/TestingExamples/TestingExample.swift


### PR DESCRIPTION
Adds repo-specific indices for Examples and Documentation folders. English-only; no placeholders.